### PR TITLE
Remove the nightly feature 

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -8,10 +8,10 @@ pub fn generate(syntax: Vec<(Syntax, Span)>) -> TokenStream {
 
     for (item, span) in syntax {
         let push = match item {
-            Syntax::Opcode(opcode) =>generate_opcode(opcode, span),
+            Syntax::Opcode(opcode) => generate_opcode(opcode, span),
             Syntax::Bytes(bytes) => generate_bytes(bytes, span),
             Syntax::Int(int) => generate_int(int, span),
-            Syntax::Escape(expression) => generate_escape(expression, span)
+            Syntax::Escape(expression) => generate_escape(expression, span),
         };
         tokens.extend(push);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,6 @@
 //! **Example:**
 //!
 //! ```rust
-//! #![feature(proc_macro_hygiene)]
-//!
 //! # use bitcoin_script::{script, define_pushable};
 //!
 //! # define_pushable!();
@@ -58,7 +56,6 @@
 //! All normal opcodes are available, in the form `OP_X`.
 //!
 //! ```rust
-//! # #![feature(proc_macro_hygiene)]
 //! # use bitcoin_script::{script, define_pushable};
 //! # define_pushable!();
 //! let script = script!(OP_CHECKSIG OP_VERIFY);
@@ -73,7 +70,6 @@
 //! -`255` will resolve to a length-delimited varint: `0x02ff00` (note the extra zero byte, due to the way Bitcoin scripts use the most-significant bit to represent the sign)`
 //!
 //! ```rust
-//! # #![feature(proc_macro_hygiene)]
 //! # use bitcoin_script::{script, define_pushable};
 //! # define_pushable!();
 //! let script = script!(123 -456 999999);
@@ -84,7 +80,6 @@
 //! Hex strings can be specified, prefixed with `0x`.
 //!
 //! ```rust
-//! # #![feature(proc_macro_hygiene)]
 //! # use bitcoin_script::{script, define_pushable};
 //! # define_pushable!();
 //! let script = script!(
@@ -106,7 +101,6 @@
 //!
 //!
 //! ```rust
-//! # #![feature(proc_macro_hygiene)]
 //! # use bitcoin_script::{script, define_pushable};
 //! # define_pushable!();
 //! let bytes = vec![1, 2, 3];
@@ -117,8 +111,6 @@
 //!     <2016 * 5> OP_CSV
 //! };
 //! ```
-
-#![feature(proc_macro_hygiene)]
 
 mod generate;
 mod parse;
@@ -182,7 +174,10 @@ pub fn define_pushable(_: TokenStream) -> TokenStream {
                     self
                 }
 
-                pub fn push_x_only_key(mut self, x_only_key: &::bitcoin::XOnlyPublicKey) -> Builder {
+                pub fn push_x_only_key(
+                    mut self,
+                    x_only_key: &::bitcoin::XOnlyPublicKey,
+                ) -> Builder {
                     self.0 = self.0.push_x_only_key(x_only_key);
                     self
                 }
@@ -244,7 +239,8 @@ pub fn define_pushable(_: TokenStream) -> TokenStream {
             }
             impl NotU8Pushable for ::bitcoin::ScriptBuf {
                 fn bitcoin_script_push(self, builder: Builder) -> Builder {
-                    let mut script_vec = Vec::with_capacity(builder.0.as_bytes().len() + self.as_bytes().len());
+                    let mut script_vec =
+                        Vec::with_capacity(builder.0.as_bytes().len() + self.as_bytes().len());
                     script_vec.extend_from_slice(builder.as_bytes());
                     script_vec.extend_from_slice(self.as_bytes());
                     Builder::from(script_vec)

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -152,7 +152,7 @@ where
             Group(block) if block.delimiter() == Delimiter::Brace => {
                 let inner_block = block.stream();
                 escape.extend(quote! {
-                    {   
+                    {
                         let next_script = script !{
                             #inner_block
                         };

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 use bitcoin::{opcodes::all::OP_ADD, ScriptBuf};
 use bitcoin_script::{define_pushable, script};
 
@@ -193,7 +191,13 @@ fn test_simple() {
         }
     };
 
-    assert_eq!(script.as_bytes(), vec![86, 122, 91, 122, 86, 122, 92, 122, 86, 122, 93, 122, 86, 122, 94, 122, 86, 122, 95, 122, 86, 122, 96, 122]);
+    assert_eq!(
+        script.as_bytes(),
+        vec![
+            86, 122, 91, 122, 86, 122, 92, 122, 86, 122, 93, 122, 86, 122, 94, 122, 86, 122, 95,
+            122, 86, 122, 96, 122
+        ]
+    );
 }
 
 #[test]
@@ -222,5 +226,8 @@ fn test_non_optimal_opcodes() {
     };
 
     println!("{:?}", script);
-    assert_eq!(script.as_bytes(), vec![124, 109, 122, 124, 123, 83, 124, 123, 83, 122]);
+    assert_eq!(
+        script.as_bytes(),
+        vec![124, 109, 122, 124, 123, 83, 124, 123, 83, 122]
+    );
 }


### PR DESCRIPTION
It seems that in Rust 1.78.0, this feature is no longer needed and therefore we do not have to use the nightly channel.

Tested against BitVM.