### PR TITLE
Stack analzyer

### DIFF
--- a/macro/src/generate.rs
+++ b/macro/src/generate.rs
@@ -15,6 +15,7 @@ pub fn generate(syntax: Vec<(Syntax, Span)>) -> TokenStream {
         };
         tokens.extend(push);
     }
+    // tokens.extend(quote! {.analyze_stack()}); // for debug
     tokens
 }
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1,0 +1,258 @@
+use crate::builder::{Block, Builder};
+use bitcoin::blockdata::opcodes::Opcode;
+use bitcoin::blockdata::script::Instruction;
+use bitcoin::opcodes::all::*;
+use std::cmp::min;
+
+#[derive(Debug, Clone)]
+enum IfStackEle {
+    IfFlow((i32, i32)),
+    // if_flow (deepest_stack_accessed, stack_changed), else_flow(deepest_stack_accessed, stack_changed)
+    ElseFlow((i32, i32, i32, i32)),
+}
+
+#[derive(Debug, Clone)]
+pub struct StackAnalyzer {
+    deepest_stack_accessed: i32,
+    stack_changed: i32,
+    // if_stack should be empty after analyzing
+    if_stack: Vec<IfStackEle>,
+    // last constant? for handling op_roll and op_pick
+    last_constant: Option<i64>,
+}
+
+impl StackAnalyzer {
+    pub fn new() -> Self {
+        StackAnalyzer {
+            deepest_stack_accessed: 0,
+            stack_changed: 0,
+            if_stack: vec![],
+            last_constant: None,
+        }
+    }
+
+    pub fn analyze(&mut self, builder: &mut Builder) -> (i32, i32) {
+        for block in builder.blocks.iter_mut() {
+            match block {
+                Block::Call(id) => {
+                    let called_script = builder
+                        .script_map
+                        .get_mut(id)
+                        .expect("Missing entry for a called script");
+                    self.handle_sub_script(called_script.analyze_stack());
+                }
+                Block::Script(block_script) => {
+                    for instruct in block_script.instructions().into_iter() {
+                        match instruct {
+                            Err(err) => {
+                                panic!("instruction extract fail from script {}", err);
+                            }
+                            Ok(x) => match x {
+                                Instruction::PushBytes(bytes) => {
+                                    if bytes.as_bytes().len() == 1 {
+                                        // u8 -> i64
+                                        self.handle_int(bytes.as_bytes()[0] as i64);
+                                    }
+                                    self.handle_push_slice();
+                                }
+                                Instruction::Op(opcode) => {
+                                    self.handle_opcode(opcode);
+                                }
+                            },
+                        }
+                    }
+                }
+            }
+        }
+        (self.deepest_stack_accessed, self.stack_changed)
+    }
+
+    pub fn handle_int(&mut self, x: i64) {
+        // if i64(data) < 1000, last_constant is true
+        if x <= 1000 && x >= 0 {
+            self.last_constant = Some(x);
+        } else {
+            self.last_constant = None;
+        }
+    }
+
+    pub fn handle_push_slice(&mut self) {
+        self.stack_change((0, 1));
+    }
+
+    pub fn handle_opcode(&mut self, opcode: Opcode) {
+        // handle if/else flow
+        match opcode {
+            OP_IF | OP_NOTIF => {
+                self.stack_change(Self::opcode_stack_table(&opcode));
+                self.if_stack.push(IfStackEle::IfFlow((0, 0)));
+            }
+            OP_ELSE => match self.if_stack.pop().unwrap() {
+                IfStackEle::IfFlow((i, j)) => {
+                    self.if_stack.push(IfStackEle::ElseFlow((i, j, 0, 0)));
+                }
+                IfStackEle::ElseFlow(_) => {
+                    panic!("shouldn't happend")
+                }
+            },
+            OP_ENDIF => match self.if_stack.pop().unwrap() {
+                IfStackEle::IfFlow((i, j)) => {
+                    assert_eq!(j, 0, "only_if_flow shouldn't change stack status");
+                    self.stack_change((i, j));
+                }
+                IfStackEle::ElseFlow((i, j, x, y)) => {
+                    assert_eq!(
+                        j, y,
+                        "if_flow and else_flow should change stack in the same way"
+                    );
+                    self.stack_change((min(i, x), j));
+                }
+            },
+            OP_PICK => match self.last_constant {
+                Some(x) => {
+                    self.stack_change((-1 * (x + 1) as i32, 0));
+                }
+                None => {
+                    panic!("need to be handled manually for op_pick")
+                }
+            },
+            OP_ROLL => match self.last_constant {
+                Some(x) => {
+                    self.stack_change((-1 * (x + 1) as i32, -1));
+                }
+                None => {
+                    panic!("need to be handled manually for op_roll")
+                }
+            },
+            _ => {
+                self.stack_change(Self::opcode_stack_table(&opcode));
+            }
+        }
+
+        // handle last constant, used by op_roll and op_pick
+        match opcode {
+            OP_PUSHNUM_1 | OP_PUSHNUM_2 | OP_PUSHNUM_3 | OP_PUSHNUM_4 | OP_PUSHNUM_5
+            | OP_PUSHNUM_6 | OP_PUSHNUM_7 | OP_PUSHNUM_8 | OP_PUSHNUM_9 | OP_PUSHNUM_10
+            | OP_PUSHNUM_11 | OP_PUSHNUM_12 | OP_PUSHNUM_13 | OP_PUSHNUM_14 | OP_PUSHNUM_15
+            | OP_PUSHNUM_16 => self.last_constant = Some((opcode.to_u8() - 0x50) as i64),
+            _ => self.last_constant = None,
+        }
+    }
+
+    pub fn handle_sub_script(&mut self, (access, change): (i32, i32)) {
+        self.last_constant = None;
+        self.stack_change((access, change));
+    }
+
+    pub fn get_status(&self) -> (i32, i32) {
+        assert!(self.if_stack.is_empty(), "if stack is not empty");
+        (self.deepest_stack_accessed, self.stack_changed)
+    }
+
+    fn stack_change(&mut self, (access, change): (i32, i32)) {
+        match self.if_stack.last_mut() {
+            None => {
+                self.deepest_stack_accessed =
+                    min(self.deepest_stack_accessed, access + self.stack_changed);
+                self.stack_changed = self.stack_changed + change;
+            }
+            Some(IfStackEle::IfFlow((i, j))) => {
+                *i = min(*i, (*j) + access);
+                *j = *j + change
+            }
+            Some(IfStackEle::ElseFlow((_, _, x, y))) => {
+                *x = min(*x, (*y) + access);
+                *y = *y + change
+            }
+        }
+    }
+
+    /// the first return is deepest access to current stack
+    /// the second return is the impact for the stack
+    fn opcode_stack_table(data: &Opcode) -> (i32, i32) {
+        match data.clone() {
+            OP_PUSHBYTES_0 | OP_PUSHBYTES_1 | OP_PUSHBYTES_2 | OP_PUSHBYTES_3 | OP_PUSHBYTES_4
+            | OP_PUSHBYTES_5 | OP_PUSHBYTES_6 | OP_PUSHBYTES_7 | OP_PUSHBYTES_8
+            | OP_PUSHBYTES_9 | OP_PUSHBYTES_10 | OP_PUSHBYTES_11 | OP_PUSHBYTES_12
+            | OP_PUSHBYTES_13 | OP_PUSHBYTES_14 | OP_PUSHBYTES_15 | OP_PUSHBYTES_16
+            | OP_PUSHBYTES_17 | OP_PUSHBYTES_18 | OP_PUSHBYTES_19 | OP_PUSHBYTES_20
+            | OP_PUSHBYTES_21 | OP_PUSHBYTES_22 | OP_PUSHBYTES_23 | OP_PUSHBYTES_24
+            | OP_PUSHBYTES_25 | OP_PUSHBYTES_26 | OP_PUSHBYTES_27 | OP_PUSHBYTES_28
+            | OP_PUSHBYTES_29 | OP_PUSHBYTES_30 | OP_PUSHBYTES_31 | OP_PUSHBYTES_32
+            | OP_PUSHBYTES_33 | OP_PUSHBYTES_34 | OP_PUSHBYTES_35 | OP_PUSHBYTES_36
+            | OP_PUSHBYTES_37 | OP_PUSHBYTES_38 | OP_PUSHBYTES_39 | OP_PUSHBYTES_40
+            | OP_PUSHBYTES_41 | OP_PUSHBYTES_42 | OP_PUSHBYTES_43 | OP_PUSHBYTES_44
+            | OP_PUSHBYTES_45 | OP_PUSHBYTES_46 | OP_PUSHBYTES_47 | OP_PUSHBYTES_48
+            | OP_PUSHBYTES_49 | OP_PUSHBYTES_50 | OP_PUSHBYTES_51 | OP_PUSHBYTES_52
+            | OP_PUSHBYTES_53 | OP_PUSHBYTES_54 | OP_PUSHBYTES_55 | OP_PUSHBYTES_56
+            | OP_PUSHBYTES_57 | OP_PUSHBYTES_58 | OP_PUSHBYTES_59 | OP_PUSHBYTES_60
+            | OP_PUSHBYTES_61 | OP_PUSHBYTES_62 | OP_PUSHBYTES_63 | OP_PUSHBYTES_64
+            | OP_PUSHBYTES_65 | OP_PUSHBYTES_66 | OP_PUSHBYTES_67 | OP_PUSHBYTES_68
+            | OP_PUSHBYTES_69 | OP_PUSHBYTES_70 | OP_PUSHBYTES_71 | OP_PUSHBYTES_72
+            | OP_PUSHBYTES_73 | OP_PUSHBYTES_74 | OP_PUSHBYTES_75 | OP_PUSHDATA1 | OP_PUSHDATA2
+            | OP_PUSHDATA4 => (0, 1),
+            OP_PUSHNUM_NEG1 | OP_PUSHNUM_1 | OP_PUSHNUM_2 | OP_PUSHNUM_3 | OP_PUSHNUM_4
+            | OP_PUSHNUM_5 | OP_PUSHNUM_6 | OP_PUSHNUM_7 | OP_PUSHNUM_8 | OP_PUSHNUM_9
+            | OP_PUSHNUM_10 | OP_PUSHNUM_11 | OP_PUSHNUM_12 | OP_PUSHNUM_13 | OP_PUSHNUM_14
+            | OP_PUSHNUM_15 | OP_PUSHNUM_16 => (0, 1),
+            OP_NOP => (0, 0),
+            OP_IF => (-1, -1),
+            OP_NOTIF => (-1, -1),
+            OP_ELSE => {
+                panic!("depend on the data on the stack")
+            }
+            OP_ENDIF => {
+                panic!("depend on the data on the stack")
+            }
+            OP_VERIFY => (-1, -1),
+            OP_TOALTSTACK => (-1, -1),
+            OP_FROMALTSTACK => (0, 1),
+            OP_2DROP => (-2, -2),
+            OP_2DUP => (-2, 2),
+            OP_3DUP => (-3, 3),
+            OP_2OVER => (-4, 2),
+            OP_2ROT => (-3, 0),
+            OP_2SWAP => (-4, 0),
+            OP_IFDUP => {
+                panic!("depend on the data on the stack")
+            }
+            OP_DEPTH => (0, 1),
+            OP_DROP => (-1, -1),
+            OP_DUP => (-1, 1),
+            OP_NIP => (-2, -1),
+            OP_OVER => (-2, 1),
+            OP_PICK => {
+                panic!("depend on the data on the stack")
+            }
+            OP_ROLL => {
+                panic!("depend on the data on the stack")
+            }
+            OP_ROT => (-3, 0),
+            OP_SWAP => (-2, 0),
+            OP_TUCK => (-2, 1),
+            OP_SIZE => (-1, 1),
+            OP_EQUAL => (-2, -1),
+            OP_EQUALVERIFY => (-2, -2),
+            OP_1ADD | OP_1SUB | OP_NEGATE | OP_ABS | OP_NOT | OP_0NOTEQUAL => (-1, 0),
+            OP_ADD | OP_SUB | OP_BOOLAND | OP_BOOLOR | OP_NUMEQUAL => (-2, -1),
+            OP_NUMEQUALVERIFY => (-2, -2),
+            OP_NUMNOTEQUAL
+            | OP_LESSTHAN
+            | OP_GREATERTHAN
+            | OP_LESSTHANOREQUAL
+            | OP_GREATERTHANOREQUAL => (-2, -1),
+            OP_MIN | OP_MAX => (-2, -1),
+            OP_WITHIN => (-3, -2),
+            OP_RIPEMD160 | OP_SHA1 | OP_SHA256 | OP_HASH160 | OP_HASH256 => (-1, 0),
+            OP_CHECKSIG => (-2, -1),
+            OP_CHECKSIGVERIFY => (-2, -2),
+            OP_NOP1 | OP_NOP4 | OP_NOP5 | OP_NOP6 | OP_NOP7 | OP_NOP8 | OP_NOP9 | OP_NOP10 => {
+                (0, 0)
+            }
+            OP_CLTV | OP_CSV => (1, 1),
+            _ => {
+                panic!("not implemantation")
+            }
+        }
+    }
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -184,7 +184,18 @@ impl Builder {
         (chunks, builder.compile())
     }
 
-    pub fn analyze_stack(&mut self) -> (i32, i32) {
+    pub fn analyze_stack(mut self) -> Self {
+        match self.stack_hint {
+            Some(_) => self,
+            None => {
+                let mut analyzer = StackAnalyzer::new();
+                analyzer.analyze(&mut self);
+                self
+            }
+        }
+    }
+
+    pub fn get_stack(&mut self) -> (i32, i32) {
         match self.stack_hint {
             Some(x) => x,
             None => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
-pub mod chunker;
+pub mod analyzer;
 pub mod builder;
+pub mod chunker;
 
 pub use crate::builder::Builder as Script;
-pub use script_macro::script;
+pub use analyzer::StackAnalyzer;
 pub use chunker::{Chunker, ChunkerError};
-
+pub use script_macro::script;

--- a/tests/test_analyzer.rs
+++ b/tests/test_analyzer.rs
@@ -1,0 +1,77 @@
+use bitcoin_script::script;
+use bitcoin_script::Script;
+
+#[test]
+fn test_plain() {
+    let mut script = script! (
+        OP_ADD
+        OP_ADD
+        OP_ADD
+    );
+    let (x, y) = script.analyze_stack();
+    assert_eq!(x, -4);
+    assert_eq!(y, -3);
+}
+
+fn inner_fn1() -> Script {
+    script!(
+        {10}
+        OP_ROLL
+        {2}
+        OP_ROLL
+        OP_ADD
+    )
+}
+
+fn inner_fn2() -> Script {
+    script!(
+        {1}
+        OP_DUP
+        OP_TOALTSTACK
+        {2}
+        OP_DUP
+        OP_TOALTSTACK
+        OP_GREATERTHAN
+        OP_IF
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        OP_ADD
+        OP_ELSE
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        OP_SUB
+        OP_ENDIF
+    )
+}
+
+#[test]
+fn test_deepthest() {
+    let mut script = script! (
+        {inner_fn1()}
+        {inner_fn1()}
+        OP_ADD
+    );
+    let (x, y) = script.analyze_stack();
+    assert_eq!([x, y], [-11, -3]);
+
+    let mut script = script! (
+     {inner_fn2()}
+     {inner_fn2()}
+     OP_ADD
+    );
+    let (x, y) = script.analyze_stack();
+    assert_eq!([x, y], [0, 1]);
+}
+
+#[test]
+fn test_deepthest2() {
+    let mut script = script! (
+        {1}
+        OP_IF
+            { 120 }
+            OP_ADD
+        OP_ENDIF
+    );
+    let (x, y) = script.analyze_stack();
+    assert_eq!([x, y], [-1, 0]);
+}

--- a/tests/test_analyzer.rs
+++ b/tests/test_analyzer.rs
@@ -8,7 +8,7 @@ fn test_plain() {
         OP_ADD
         OP_ADD
     );
-    let (x, y) = script.analyze_stack();
+    let (x, y) = script.get_stack();
     assert_eq!(x, -4);
     assert_eq!(y, -3);
 }
@@ -51,7 +51,7 @@ fn test_deepthest() {
         {inner_fn1()}
         OP_ADD
     );
-    let (x, y) = script.analyze_stack();
+    let (x, y) = script.get_stack();
     assert_eq!([x, y], [-11, -3]);
 
     let mut script = script! (
@@ -59,7 +59,7 @@ fn test_deepthest() {
      {inner_fn2()}
      OP_ADD
     );
-    let (x, y) = script.analyze_stack();
+    let (x, y) = script.get_stack();
     assert_eq!([x, y], [0, 1]);
 }
 
@@ -72,6 +72,6 @@ fn test_deepthest2() {
             OP_ADD
         OP_ENDIF
     );
-    let (x, y) = script.analyze_stack();
+    let (x, y) = script.get_stack();
     assert_eq!([x, y], [-1, 0]);
 }


### PR DESCRIPTION
This PR adds a static stack analyzer for Script Builder.

```rust 
    let mut script = script! (
        OP_ADD
        OP_ADD
        OP_ADD
    );
    let (x, y) = script.get_stack();
    assert_eq!(x, -4);
    assert_eq!(y, -3);
```

The stack analyzer is tested through groth16 verifier. Most of groth16 verifier can be analyzed staticly, but there still are three changes for dynamic cases, which can be pulled later.

BitVM change list:
- src/fp/inv.rs Line 251: HINT
- src/bigint/std.rs Line 111: HINT
- src/bn254/curve.rs Line 417, Line 442: add one Fp::add(), it's improper to add hint to a big script 
 
https://github.com/wz14/BitVM/tree/analyze_groth16